### PR TITLE
Test suite fix and extension

### DIFF
--- a/generators/app/templates/generic/__tests__/components/Link/index.spec.tsx
+++ b/generators/app/templates/generic/__tests__/components/Link/index.spec.tsx
@@ -1,19 +1,31 @@
 import * as React from 'react'
 import { mount, shallow, render } from 'enzyme' // 'mount' for testing full lifecycle
-import Link from './../../../components/Link'
+import { default as Link } from './../../../components/Link/Link'
 
 describe('Link component', () => {
-  describe('Test group', () => {
-    it('Is mailto link rendered properly', () => {
-      const testData = {
-        type: 'mailto',
-        url: 'email@domain.com',
-        title: 'anchor'
-      }
-      const wrapper = mount(
-        <Link type="mailto" url="email@domain.com" title="anchor" />
-      )
-      expect(wrapper.find('a').text()).toBe(testData.title)
-    })
+  it('Is mailto link rendered properly', () => {
+    const testData = {
+      type: 'mailto',
+      url: 'email@domain.com',
+      title: 'anchor'
+    }
+    const wrapper = mount(
+      <Link type="mailto" url="email@domain.com" title="anchor" />
+    )
+    expect(wrapper.find('a').text()).toBe(testData.title)
+  })
+  it('Is external link rendered properly', () => {
+    const testData = {
+      type: 'external',
+      url: 'http://domain.com',
+      title: 'External link'
+    }
+    const wrapper = mount(
+      <Link type="external" url="http://domain.com" title="External link" />
+    )
+    // All expectations must be met to pass test
+    expect(wrapper.find('a').props().href).toBe(testData.url)
+    expect(wrapper.find('a').props().rel).toBe('noopener')
+    expect(wrapper.find('a').props().target).toBe('_blank')
   })
 })


### PR DESCRIPTION
Changed import in Link's test suite to import only Link component.
Test suite extended with test to check 'external' links